### PR TITLE
Convert package.json indentation to 2 spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-    "name": "nunciato.org",
-    "private": true,
-    "scripts": {
-        "start": "npm run dev",
-        "build": "turbo build",
-        "dev": "turbo dev",
-        "chris": "npm run dev -w chris",
-        "oliver": "npm run dev -w oliver",
-        "lint": "turbo lint",
-        "format": "prettier . --write --config ./prettier.config.json",
-        "clean": "git clean -fdX"
-    },
-    "devDependencies": {
-        "prettier": "^3.2.5",
-        "prettier-plugin-astro": "^0.14.1",
-        "turbo": "^2.0.14",
-        "typescript": "^5.4.5"
-    },
-    "engines": {
-        "node": ">=18"
-    },
-    "packageManager": "npm@10.5.0",
-    "workspaces": [
-        "apps/*",
-        "infra/*",
-        "packages/*"
-    ]
+  "name": "nunciato.org",
+  "private": true,
+  "scripts": {
+    "start": "npm run dev",
+    "build": "turbo build",
+    "dev": "turbo dev",
+    "chris": "npm run dev -w chris",
+    "oliver": "npm run dev -w oliver",
+    "lint": "turbo lint",
+    "format": "prettier . --write --config ./prettier.config.json",
+    "clean": "git clean -fdX"
+  },
+  "devDependencies": {
+    "prettier": "^3.2.5",
+    "prettier-plugin-astro": "^0.14.1",
+    "turbo": "^2.0.14",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "npm@10.5.0",
+  "workspaces": [
+    "apps/*",
+    "infra/*",
+    "packages/*"
+  ]
 }


### PR DESCRIPTION
This PR updates the indentation in package.json from 4 spaces to 2 spaces.

This change:
- Makes the JSON formatting more compact
- Follows modern JavaScript/JSON conventions
- Aligns with common industry standards for package.json files