### PR TITLE
Fix: Correct JSON indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "nunciato.org",
-  "private": true,
-  "scripts": {
-    "start": "npm run dev",
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "chris": "npm run dev -w chris",
-    "oliver": "npm run dev -w oliver",
-    "lint": "turbo lint && prettier . --check --config ./prettier.config.json",
-    "format": "prettier . --write --config ./prettier.config.json",
-    "clean": "git clean -fdX"
-  },
-  "devDependencies": {
-    "prettier": "^3.2.5",
-    "prettier-plugin-astro": "^0.14.1",
-    "turbo": "^2.0.14",
-    "typescript": "^5.4.5"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "packageManager": "npm@10.5.0",
-  "workspaces": [
-    "apps/*",
-    "infra/*",
-    "packages/*"
-  ]
+    "name": "nunciato.org",
+    "private": true,
+    "scripts": {
+        "start": "npm run dev",
+        "build": "turbo build",
+        "dev": "turbo dev",
+        "chris": "npm run dev -w chris",
+        "oliver": "npm run dev -w oliver",
+        "lint": "turbo lint && prettier . --check --config ./prettier.config.json",
+        "format": "prettier . --write --config ./prettier.config.json",
+        "clean": "git clean -fdX"
+    },
+    "devDependencies": {
+        "prettier": "^3.2.5",
+        "prettier-plugin-astro": "^0.14.1",
+        "turbo": "^2.0.14",
+        "typescript": "^5.4.5"
+    },
+    "engines": {
+        "node": ">=18"
+    },
+    "packageManager": "npm@10.5.0",
+    "workspaces": [
+        "apps/*",
+        "infra/*",
+        "packages/*"
+    ]
 }


### PR DESCRIPTION
This PR fixes the JSON formatting issue that was causing the build to fail.

Changes:
- Restored the 4-space indentation in package.json as required by the project's prettier config
- This should fix the failing lint step in the build pipeline

This should resolve the build error: `Code style issues found in 2 files. Run Prettier with --write to fix.`
